### PR TITLE
[icos-cp-backend] Switch to application/x-www-form-urlencoded content type for SPARQL queries

### DIFF
--- a/icos-cp-backend/package.json
+++ b/icos-cp-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icos-cp-backend",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Backend comunication and data formats",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/icos-cp-backend/src/sparql.ts
+++ b/icos-cp-backend/src/sparql.ts
@@ -53,9 +53,9 @@ export function sparql<Mandatories extends string, Optionals extends string>(
 			headers: new Headers({
 				...cacheHeader,
 				'Accept': 'application/json',
-				'Content-Type': 'text/plain'
+				'Content-Type': 'application/x-www-form-urlencoded'
 			}),
-			body: query.text
+			body: new URLSearchParams({query: query.text})
 		})
 		.then(checkStatus)
 		.then(response => response.json());


### PR DESCRIPTION
SPARQL queries were sent as plain text, but some of them started to be too long for it to work.