### PR TITLE
[icos-cp-toaster] Ensure alert disappears completely

### DIFF
--- a/icos-cp-toaster/package.json
+++ b/icos-cp-toaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icos-cp-toaster",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Requires Bootstrap css. React toaster component. It displays a toaster in upper right corner with Info, Success, Warning or Error styling.",
   "main": "lib/index.js",
   "scripts": {

--- a/icos-cp-toaster/src/Toaster.jsx
+++ b/icos-cp-toaster/src/Toaster.jsx
@@ -1,111 +1,99 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
-export class Toaster extends Component {
-
-	handleCloseToaster() {
-		if (this.props.closeToast) {
-			this.props.closeToast();
-		}
+export function Toaster({ toasterData, closeToast }) {
+	if (!toasterData || !toasterData.header || !toasterData.message) {
+		return null;
 	}
 
-	render() {
-		const props = this.props;
-		const { header, message, className } = props.toasterData
-			? props.toasterData
-			: { header: null, message: null, className: null };
-		const divStyle = header && message && className
-			? { position: 'fixed', top: 15, right: 15, width: '400px', zIndex: 9999, transition: 'opacity 1s', opacity: props.opacity }
-			: {};
-
-		return (
-			<div style={divStyle} className={className}>
-				<h4 className="alert-heading">{header}</h4>
-				<div>{message}</div>
-				<button type="button" className="btn-close" aria-label="Close" onClick={this.handleCloseToaster.bind(this)}></button>
-			</div>
-		);
-	}
+	return (
+		<div
+			className={toasterData.className}
+			style={{ position: 'fixed', top: 15, right: 15, width: 400, zIndex: 9999 }}
+			role="alert"
+		>
+			<h4 className="alert-heading">{toasterData.header}</h4>
+			<div>{toasterData.message}</div>
+			<button type="button" className="btn-close" aria-label="Close" onClick={closeToast} />
+		</div>
+	);
 }
 
-export class AnimatedToasters extends Component {
+function AnimatedToast({ toasterData, autoCloseDelay, onClose }) {
+	const [show, setShow] = useState(false);
 
-	constructor(props) {
-		super(props);
-		this.autoClose = props.autoClose ?? true;
-		this.autoCloseDelay = props.autoCloseDelay ?? this.autoClose ? 5000 : 0;
+	useEffect(() => {
+		// Defer adding 'show' by one frame so the initial opacity:0 render is
+		// committed first, giving Bootstrap's CSS transition something to animate from.
+		const id = requestAnimationFrame(() => setShow(true));
+		return () => cancelAnimationFrame(id);
+	}, []);
 
-		this.state = {
-			toasterData: props.toasterData
-		};
+	useEffect(() => {
+		if (autoCloseDelay > 0) {
+			const t = setTimeout(() => setShow(false), autoCloseDelay);
+			return () => clearTimeout(t);
+		}
+	}, [autoCloseDelay]);
+
+	function handleClose() {
+		setShow(false);
 	}
 
-	componentDidUpdate() {
-		this.state.toasterData = this.props.toasterData;
+	function handleTransitionEnd() {
+		if (!show) {
+			onClose(toasterData.id);
+		}
 	}
 
-	handleCloseToast(id) {
-		const newToasterData = this.state.toasterData.filter(td => td.id !== id);
-		this.setState({ toasterData: newToasterData });
-	}
-
-	render() {
-		const state = this.state;
-
-		return (state.toasterData &&
-			<Animate
-				key={state.toasterData.id}
-				autoCloseDelay={this.autoCloseDelay}
-				toasterData={state.toasterData}
-				closeToast={this.handleCloseToast.bind(this)}
-			/>
-		);
-	}
+	return (
+		<div
+			className={`${toasterData.className} fade${show ? ' show' : ''}`}
+			style={{ width: 400, marginBottom: 8 }}
+			role="alert"
+			onTransitionEnd={handleTransitionEnd}
+		>
+			<h4 className="alert-heading">{toasterData.header}</h4>
+			<div>{toasterData.message}</div>
+			<button type="button" className="btn-close" aria-label="Close" onClick={handleClose} />
+		</div>
+	);
 }
 
-class Animate extends Component {
-	state = { closed: false, opacity: 0 };
-	autoCloseTimer = null;
+export function AnimatedToasters({ toasterData, autoClose = true, autoCloseDelay }) {
+	const delay = autoCloseDelay ?? (autoClose ? 5000 : 0);
+	const [toasts, setToasts] = useState([]);
+	const seenIds = useRef(new Set());
 
-	componentDidMount() {
-		this.startTimer();
-	}
-
-	componentDidUpdate() {
-		if (this.props.toasterData && this.props.toasterData.closed !== undefined && !this.props.toasterData.closed) {
-			clearTimeout(this.autoCloseTimer);
-			this.startTimer();
+	useEffect(() => {
+		if (!toasterData) {
+			return;
 		}
-	}
-
-	startTimer() {
-		this.setState({ opacity: 1 });
-		if (this.props.autoCloseDelay > 0) {
-			this.autoCloseTimer = setTimeout(() => {
-				this.close();
-			}, this.props.autoCloseDelay);
+		const items = Array.isArray(toasterData) ? toasterData : [toasterData];
+		const newItems = items.filter(td => !seenIds.current.has(td.id));
+		if (newItems.length > 0) {
+			newItems.forEach(td => seenIds.current.add(td.id));
+			setToasts(prev => [...prev, ...newItems]);
 		}
+	}, [toasterData]);
+
+	function removeToast(id) {
+		setToasts(prev => prev.filter(t => t.id !== id));
 	}
 
-	handleInnerToasterClose() {
-		clearTimeout(this.autoCloseTimer);
-		this.close();
+	if (!toasts.length) {
+		return null;
 	}
 
-	close() {
-		this.setState({ closed: true, opacity: 0 });
-	}
-
-	handleFadeOutDone(id) {
-		if (this.props.closeToast) {
-			this.props.closeToast(id);
-		}
-	}
-
-	render() {
-		return <Toaster
-			opacity={this.state.opacity}
-			toasterData={this.props.toasterData}
-			closeToast={this.handleInnerToasterClose.bind(this)}
-		/>;
-	}
+	return (
+		<div style={{ position: 'fixed', top: 15, right: 15, zIndex: 9999 }}>
+			{toasts.map(td => (
+				<AnimatedToast
+					key={td.id}
+					toasterData={td}
+					autoCloseDelay={delay}
+					onClose={removeToast}
+				/>
+			))}
+		</div>
+	);
 }

--- a/icos-cp-toaster/src/Toaster.jsx
+++ b/icos-cp-toaster/src/Toaster.jsx
@@ -43,9 +43,8 @@ export class AnimatedToasters extends Component {
 		this.state.toasterData = this.props.toasterData;
 	}
 
-	handleCloseToast(id) {
-		const newToasterData = this.state.toasterData.filter(td => td.id !== id);
-		this.setState({ toasterData: newToasterData });
+	handleCloseToast() {
+		this.setState({ toasterData: null });
 	}
 
 	render() {

--- a/icos-cp-toaster/src/Toaster.jsx
+++ b/icos-cp-toaster/src/Toaster.jsx
@@ -1,99 +1,118 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { Component } from 'react';
 
-export function Toaster({ toasterData, closeToast }) {
-	if (!toasterData || !toasterData.header || !toasterData.message) {
-		return null;
+export class Toaster extends Component {
+
+	handleCloseToaster() {
+		if (this.props.closeToast) {
+			this.props.closeToast();
+		}
 	}
 
-	return (
-		<div
-			className={toasterData.className}
-			style={{ position: 'fixed', top: 15, right: 15, width: 400, zIndex: 9999 }}
-			role="alert"
-		>
-			<h4 className="alert-heading">{toasterData.header}</h4>
-			<div>{toasterData.message}</div>
-			<button type="button" className="btn-close" aria-label="Close" onClick={closeToast} />
-		</div>
-	);
+	render() {
+		const props = this.props;
+		const { header, message, className } = props.toasterData
+			? props.toasterData
+			: { header: null, message: null, className: null };
+		const divStyle = header && message && className
+			? { position: 'fixed', top: 15, right: 15, width: '400px', zIndex: 9999, transition: 'opacity 1s', opacity: props.opacity }
+			: {};
+
+		return (
+			<div style={divStyle} className={className} onTransitionEnd={props.onTransitionEnd}>
+				<h4 className="alert-heading">{header}</h4>
+				<div>{message}</div>
+				<button type="button" className="btn-close" aria-label="Close" onClick={this.handleCloseToaster.bind(this)}></button>
+			</div>
+		);
+	}
 }
 
-function AnimatedToast({ toasterData, autoCloseDelay, onClose }) {
-	const [show, setShow] = useState(false);
+export class AnimatedToasters extends Component {
 
-	useEffect(() => {
-		// Defer adding 'show' by one frame so the initial opacity:0 render is
-		// committed first, giving Bootstrap's CSS transition something to animate from.
-		const id = requestAnimationFrame(() => setShow(true));
-		return () => cancelAnimationFrame(id);
-	}, []);
+	constructor(props) {
+		super(props);
+		this.autoClose = props.autoClose ?? true;
+		this.autoCloseDelay = props.autoCloseDelay ?? this.autoClose ? 5000 : 0;
 
-	useEffect(() => {
-		if (autoCloseDelay > 0) {
-			const t = setTimeout(() => setShow(false), autoCloseDelay);
-			return () => clearTimeout(t);
-		}
-	}, [autoCloseDelay]);
-
-	function handleClose() {
-		setShow(false);
+		this.state = {
+			toasterData: props.toasterData
+		};
 	}
 
-	function handleTransitionEnd() {
-		if (!show) {
-			onClose(toasterData.id);
-		}
+	componentDidUpdate() {
+		this.state.toasterData = this.props.toasterData;
 	}
 
-	return (
-		<div
-			className={`${toasterData.className} fade${show ? ' show' : ''}`}
-			style={{ width: 400, marginBottom: 8 }}
-			role="alert"
-			onTransitionEnd={handleTransitionEnd}
-		>
-			<h4 className="alert-heading">{toasterData.header}</h4>
-			<div>{toasterData.message}</div>
-			<button type="button" className="btn-close" aria-label="Close" onClick={handleClose} />
-		</div>
-	);
+	handleCloseToast(id) {
+		const newToasterData = this.state.toasterData.filter(td => td.id !== id);
+		this.setState({ toasterData: newToasterData });
+	}
+
+	render() {
+		const state = this.state;
+
+		return (state.toasterData &&
+			<Animate
+				key={state.toasterData.id}
+				autoCloseDelay={this.autoCloseDelay}
+				toasterData={state.toasterData}
+				closeToast={this.handleCloseToast.bind(this)}
+			/>
+		);
+	}
 }
 
-export function AnimatedToasters({ toasterData, autoClose = true, autoCloseDelay }) {
-	const delay = autoCloseDelay ?? (autoClose ? 5000 : 0);
-	const [toasts, setToasts] = useState([]);
-	const seenIds = useRef(new Set());
+class Animate extends Component {
+	state = { closed: false, opacity: 0 };
+	autoCloseTimer = null;
 
-	useEffect(() => {
-		if (!toasterData) {
-			return;
-		}
-		const items = Array.isArray(toasterData) ? toasterData : [toasterData];
-		const newItems = items.filter(td => !seenIds.current.has(td.id));
-		if (newItems.length > 0) {
-			newItems.forEach(td => seenIds.current.add(td.id));
-			setToasts(prev => [...prev, ...newItems]);
-		}
-	}, [toasterData]);
-
-	function removeToast(id) {
-		setToasts(prev => prev.filter(t => t.id !== id));
+	componentDidMount() {
+		this.startTimer();
 	}
 
-	if (!toasts.length) {
-		return null;
+	componentDidUpdate() {
+		if (this.props.toasterData && this.props.toasterData.closed !== undefined && !this.props.toasterData.closed) {
+			clearTimeout(this.autoCloseTimer);
+			this.startTimer();
+		}
 	}
 
-	return (
-		<div style={{ position: 'fixed', top: 15, right: 15, zIndex: 9999 }}>
-			{toasts.map(td => (
-				<AnimatedToast
-					key={td.id}
-					toasterData={td}
-					autoCloseDelay={delay}
-					onClose={removeToast}
-				/>
-			))}
-		</div>
-	);
+	startTimer() {
+		this.setState({ opacity: 1 });
+		if (this.props.autoCloseDelay > 0) {
+			this.autoCloseTimer = setTimeout(() => {
+				this.close();
+			}, this.props.autoCloseDelay);
+		}
+	}
+
+	handleInnerToasterClose() {
+		clearTimeout(this.autoCloseTimer);
+		this.close();
+	}
+
+	close() {
+		this.setState({ closed: true, opacity: 0 });
+	}
+
+	handleFadeOutDone(id) {
+		if (this.props.closeToast) {
+			this.props.closeToast(id);
+		}
+	}
+
+	handleTransitionEnd() {
+		if (this.state.closed) {
+			this.handleFadeOutDone(this.props.toasterData.id);
+		}
+	}
+
+	render() {
+		return <Toaster
+			opacity={this.state.opacity}
+			toasterData={this.props.toasterData}
+			closeToast={this.handleInnerToasterClose.bind(this)}
+			onTransitionEnd={this.handleTransitionEnd.bind(this)}
+		/>;
+	}
 }


### PR DESCRIPTION
Previously, the alerts would not actually disappear -- the opacity would go to 0 but they would remain in the DOM and cover up content, rendering the content below impossible to interact with.

Now, the alerts will disappear completely, both when fading out and when closed with the close button.